### PR TITLE
i18nでアプリを日本語化しました！

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "git.ignoreLimitWarning": true
+}

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'jbuilder', '~> 2.5'
 gem 'bootsnap', '>= 1.1.0', require: false
 gem 'haml-rails'
 gem 'erb2haml'
+gem 'enum_help'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -81,6 +81,8 @@ GEM
     crass (1.0.4)
     database_cleaner (1.7.0)
     diff-lcs (1.3)
+    enum_help (0.0.17)
+      activesupport (>= 3.0.0)
     erb2haml (0.1.5)
       html2haml
     erubi (1.7.1)
@@ -302,6 +304,7 @@ DEPENDENCIES
   chromedriver-helper
   coffee-rails (~> 4.2)
   database_cleaner
+  enum_help
   erb2haml
   factory_bot_rails
   faker

--- a/app/views/tasks/_form.html.haml
+++ b/app/views/tasks/_form.html.haml
@@ -1,7 +1,6 @@
 = form_for @task do |f|
   - if @task.errors.any?
     #error_explanation
-      %h2= "#{pluralize(@task.errors.count, "error")} prohibited this task from being saved:"
       %ul
         - @task.errors.full_messages.each do |message|
           %li= message
@@ -14,13 +13,14 @@
     = f.text_area :description
   %div
     = f.label :status
-    = f.select :status, Task.statuses.keys
+    = f.select :status, Task.statuses_i18n.invert
   %div
     = f.label :priority
-    = f.select :priority, Task.priorities.keys
+    = f.select :priority, Task.priorities_i18n.invert
   %div
     = f.label :deadline
     = f.datetime_local_field :deadline
 
   .actions
-    = f.submit 'Save'
+    = f.submit t('common.save')
+

--- a/app/views/tasks/_task.json.jbuilder
+++ b/app/views/tasks/_task.json.jbuilder
@@ -1,2 +1,0 @@
-json.extract! task, :id, :created_at, :updated_at
-json.url task_url(task, format: :json)

--- a/app/views/tasks/edit.html.haml
+++ b/app/views/tasks/edit.html.haml
@@ -1,7 +1,7 @@
-%h1 Editing task
+%h1= t '.title'
 
 = render 'form'
 
-= link_to 'Show', @task
-\|
-= link_to 'Back', tasks_path
+= link_to t('common.show'), @task
+|
+= link_to t('common.back'), tasks_path

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -1,24 +1,24 @@
-%h1 Listing tasks
+%h1= t '.title'
 
-%table{ border: '1' }
+%table{ border: 1 }
   %thead
     %tr
-      %th title
-      %th status
-      %th priority
-      %th deadline
-      %th actions
+      %th= Task.human_attribute_name(:title)
+      %th= Task.human_attribute_name(:status)
+      %th= Task.human_attribute_name(:priority)
+      %th= Task.human_attribute_name(:deadline)
+      %th Actions
   %tbody
     - @tasks.each do |task|
       %tr
         %td= task.title
-        %td= task.status
-        %td= task.priority
-        %td= task.deadline
+        %td= task.status_i18n
+        %td= task.priority_i18n
+        %td= l(task.deadline, format: :long)
         %td 
-          = link_to 'Show', task
-          = link_to 'Edit', edit_task_path(task)
-          = link_to 'Destroy', task, method: :delete
+          = link_to t('common.show'), task
+          = link_to t('common.edit'), edit_task_path(task)
+          = link_to t('common.destroy'), task, method: :delete
 %br
 
-= link_to 'New Task', new_task_path
+= link_to t('common.new') + t('activerecord.models.task'), new_task_path

--- a/app/views/tasks/index.json.jbuilder
+++ b/app/views/tasks/index.json.jbuilder
@@ -1,1 +1,0 @@
-json.array! @tasks, partial: 'tasks/task', as: :task

--- a/app/views/tasks/new.html.haml
+++ b/app/views/tasks/new.html.haml
@@ -1,5 +1,5 @@
-%h1 New task
+%h1= t '.title'
 
 = render 'form'
 
-= link_to 'Back', tasks_path
+= link_to t('common.back'), tasks_path

--- a/app/views/tasks/show.html.haml
+++ b/app/views/tasks/show.html.haml
@@ -1,19 +1,22 @@
 %p#notice= notice
 %h1= @task.title
 %div
-  %p Description
-  %p= @task.description
+  = label :task, :description
+  %br
+  = @task.description
 %div
-  %p Status
-  %p= @task.status
+  = label :task, :status
+  ：
+  = @task.status_i18n
 %div
-  %p Priority
-  %p= @task.priority
+  = label :task, :priority
+  ：
+  = @task.priority_i18n
 %div
-  %p Deadline
-  %p= @task.deadline
+  = label :task, :deadline
+  ：
+  = l(@task.deadline, format: :long)
 
-
-= link_to 'Edit', edit_task_path(@task)
-\|
-= link_to 'Back', tasks_path
+= link_to t('common.edit'), edit_task_path(@task)
+|
+= link_to t('common.back'), tasks_path

--- a/app/views/tasks/show.json.jbuilder
+++ b/app/views/tasks/show.json.jbuilder
@@ -1,1 +1,0 @@
-json.partial! "tasks/task", task: @task

--- a/config/application.rb
+++ b/config/application.rb
@@ -12,6 +12,7 @@ module Cando
     config.load_defaults 5.2
     config.time_zone = 'Tokyo'
     config.active_record.default_timezone = :local
+    config.i18n.default_locale = :ja
     config.generators do |g|
       g.test_framework :rspec,
         fixtures: true,

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,204 @@
+ja:
+  activerecord:
+    errors:
+      messages:
+        record_invalid: "バリデーションに失敗しました: %{errors}"
+        restrict_dependent_destroy:
+          has_one: "%{record}が存在しているので削除できません"
+          has_many: "%{record}が存在しているので削除できません"
+  date:
+    abbr_day_names:
+    - 日
+    - 月
+    - 火
+    - 水
+    - 木
+    - 金
+    - 土
+    abbr_month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    day_names:
+    - 日曜日
+    - 月曜日
+    - 火曜日
+    - 水曜日
+    - 木曜日
+    - 金曜日
+    - 土曜日
+    formats:
+      default: "%Y/%m/%d"
+      long: "%Y年%m月%d日(%a)"
+      short: "%m/%d"
+    month_names:
+    -
+    - 1月
+    - 2月
+    - 3月
+    - 4月
+    - 5月
+    - 6月
+    - 7月
+    - 8月
+    - 9月
+    - 10月
+    - 11月
+    - 12月
+    order:
+    - :year
+    - :month
+    - :day
+  datetime:
+    distance_in_words:
+      about_x_hours:
+        one: 約1時間
+        other: 約%{count}時間
+      about_x_months:
+        one: 約1ヶ月
+        other: 約%{count}ヶ月
+      about_x_years:
+        one: 約1年
+        other: 約%{count}年
+      almost_x_years:
+        one: 1年弱
+        other: "%{count}年弱"
+      half_a_minute: 30秒前後
+      less_than_x_minutes:
+        one: 1分以内
+        other: "%{count}分未満"
+      less_than_x_seconds:
+        one: 1秒以内
+        other: "%{count}秒未満"
+      over_x_years:
+        one: 1年以上
+        other: "%{count}年以上"
+      x_days:
+        one: 1日
+        other: "%{count}日"
+      x_minutes:
+        one: 1分
+        other: "%{count}分"
+      x_months:
+        one: 1ヶ月
+        other: "%{count}ヶ月"
+      x_years:
+        one: 1年
+        other: "%{count}年"
+      x_seconds:
+        one: 1秒
+        other: "%{count}秒"
+    prompts:
+      day: 日
+      hour: 時
+      minute: 分
+      month: 月
+      second: 秒
+      year: 年
+  errors:
+    format: "%{attribute}%{message}"
+    messages:
+      accepted: を受諾してください
+      blank: を入力してください
+      present: は入力しないでください
+      confirmation: と%{attribute}の入力が一致しません
+      empty: を入力してください
+      equal_to: は%{count}にしてください
+      even: は偶数にしてください
+      exclusion: は予約されています
+      greater_than: は%{count}より大きい値にしてください
+      greater_than_or_equal_to: は%{count}以上の値にしてください
+      inclusion: は一覧にありません
+      invalid: は不正な値です
+      less_than: は%{count}より小さい値にしてください
+      less_than_or_equal_to: は%{count}以下の値にしてください
+      model_invalid: "バリデーションに失敗しました: %{errors}"
+      not_a_number: は数値で入力してください
+      not_an_integer: は整数で入力してください
+      odd: は奇数にしてください
+      required: を入力してください
+      taken: はすでに存在します
+      too_long: は%{count}文字以内で入力してください
+      too_short: は%{count}文字以上で入力してください
+      wrong_length: は%{count}文字で入力してください
+      other_than: は%{count}以外の値にしてください
+    template:
+      body: 次の項目を確認してください
+      header:
+        one: "%{model}にエラーが発生しました"
+        other: "%{model}に%{count}個のエラーが発生しました"
+  helpers:
+    select:
+      prompt: 選択してください
+    submit:
+      create: 登録する
+      submit: 保存する
+      update: 更新する
+  number:
+    currency:
+      format:
+        delimiter: ","
+        format: "%n%u"
+        precision: 0
+        separator: "."
+        significant: false
+        strip_insignificant_zeros: false
+        unit: 円
+    format:
+      delimiter: ","
+      precision: 3
+      separator: "."
+      significant: false
+      strip_insignificant_zeros: false
+    human:
+      decimal_units:
+        format: "%n %u"
+        units:
+          billion: 十億
+          million: 百万
+          quadrillion: 千兆
+          thousand: 千
+          trillion: 兆
+          unit: ''
+      format:
+        delimiter: ''
+        precision: 3
+        significant: true
+        strip_insignificant_zeros: true
+      storage_units:
+        format: "%n%u"
+        units:
+          byte: バイト
+          gb: GB
+          kb: KB
+          mb: MB
+          tb: TB
+    percentage:
+      format:
+        delimiter: ''
+        format: "%n%"
+    precision:
+      format:
+        delimiter: ''
+  support:
+    array:
+      last_word_connector: 、
+      two_words_connector: 、
+      words_connector: 、
+  time:
+    am: 午前
+    formats:
+      default: "%Y年%m月%d日(%a) %H時%M分%S秒 %z"
+      long: "%Y/%m/%d %H:%M"
+      short: "%m/%d %H:%M"
+    pm: 午後

--- a/config/locales/model.ja.yml
+++ b/config/locales/model.ja.yml
@@ -1,0 +1,21 @@
+ja:
+  activerecord:
+    models:
+      task: タスク
+    attributes:
+      task:
+        title: タイトル
+        description: 説明
+        status: ステータス
+        priority: 優先度
+        deadline: 期限
+  enums:
+    task:
+      status:
+        todo: Todo
+        doing: Doing
+        done: Done
+      priority:
+        low: 低
+        medium: 中
+        high: 高

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -1,0 +1,17 @@
+ja:  
+  tasks:
+    index:
+      title: タスク一覧
+    new:
+      title: 新規タスク
+    show:
+      title: タスク詳細
+    edit:
+      title: タスク編集
+  common:
+    back: 戻る
+    show: 詳細
+    new: 新規
+    edit: 編集
+    destroy: 削除
+    save: 保存


### PR DESCRIPTION
# やったこと 💪 
* 下記を行いました(・∀・)
> ステップ9: アプリの日本語部分を共通化しよう
> Railsのi18nの仕組みを利用して、日本語リソースの共通化をしましょう

# 工夫したこと ✨ 
* rails共通部分の日本語化は下記からファイルを取得しておこないました。
  https://github.com/svenfuchs/rails-i18n/blob/master/rails/locale/ja.yml
* `enum_help`を使ってenum部分も日本語化しました 😀 
  https://github.com/zmbacker/enum_help
* view用の`view.ja.yml`に画面のタイトル、ボタンの名前を定義して、そこから日本語名を取得するようにしました 😀 

# 困ったこと 😢 
* enum部分のi18nでちょっとハマったけど、ここを確認してなんとかなった！
  http://kimuraysp.hatenablog.com/entry/2016/05/19/233144
* 困ったことではないけど、ファイル分割しても`config/locales`配下に`hoge.ja.yml`みたいな感じで配置すれば、よしなに読み込んでくれるの便利ですね。