### PR TITLE
タスクの検索機能(タイトル・ステータス)を実装しました

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,6 +3,12 @@ class TasksController < ApplicationController
     @tasks = Task.all
   end
 
+  def search
+    prepare_search_attr
+    @tasks = Task.where(@search_attr)
+    render :index
+  end
+
   def show
     @task = Task.find(params[:id])
   end
@@ -40,6 +46,12 @@ class TasksController < ApplicationController
   end
 
   private
+
+  def prepare_search_attr
+    @search_attr = task_params
+    # 未指定の場合は検索条件から削除
+    @search_attr.delete_if {|_key, val| val.blank? }
+  end
 
   def task_params
     params.require(:task).permit(:title, :description, :status, :priority, :deadline)

--- a/app/views/tasks/_search_form.html.haml
+++ b/app/views/tasks/_search_form.html.haml
@@ -1,0 +1,5 @@
+%div
+  = form_tag(search_tasks_path, method: :get) do
+    = text_field_tag 'task[title]'
+    = select_tag 'task[status]', options_for_select(Task.statuses_i18n.invert), prompt: '-'
+    = submit_tag '検索'

--- a/app/views/tasks/_search_form.html.haml
+++ b/app/views/tasks/_search_form.html.haml
@@ -1,5 +1,7 @@
 %div
   = form_tag(search_tasks_path, method: :get) do
+    = label_tag :task_title, Task.human_attribute_name(:title)
     = text_field_tag 'task[title]'
+    = label_tag :task_status, Task.human_attribute_name(:status)
     = select_tag 'task[status]', options_for_select(Task.statuses_i18n.invert), prompt: '-'
-    = submit_tag '検索'
+    = submit_tag t('common.search')

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -1,5 +1,6 @@
 %h1= t '.title'
-
+= render 'search_form'
+%br
 %table{ border: 1 }
   %thead
     %tr

--- a/config/locales/view.ja.yml
+++ b/config/locales/view.ja.yml
@@ -15,3 +15,4 @@ ja:
     edit: 編集
     destroy: 削除
     save: 保存
+    search: 検索

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
-  resources :tasks
+  resources :tasks do
+    collection{ get :search }
+  end
 end

--- a/spec/features/tasks/create_update_destroy_spec.rb
+++ b/spec/features/tasks/create_update_destroy_spec.rb
@@ -5,30 +5,30 @@ RSpec.describe 'タスクの登録・更新・削除', type: :feature, js: true 
     context '正常な入力値でタスクを登録した場合' do
       before do
         visit new_task_path
-        fill_in 'Title',       with: task.title
-        fill_in 'Description', with: task.description
-        select task.status,    from: 'Status'
-        select task.priority,  from: 'Priority'
-        fill_in 'Deadline',    with: task.deadline
+        fill_in Task.human_attribute_name(:title),       with: task.title
+        fill_in Task.human_attribute_name(:description), with: task.description
+        fill_in Task.human_attribute_name(:deadline),    with: task.deadline
+        select Task.statuses_i18n[task.status],     from: Task.human_attribute_name(:status)
+        select Task.priorities_i18n[task.priority], from: Task.human_attribute_name(:priority)
       end
 
       it 'タスクが登録されること' do
-        expect { click_button 'Save' }.to change(Task, :count).by(1)
+        expect { click_button I18n.t('common.save') }.to change(Task, :count).by(1)
       end
     end
 
     context '異常な入力値でタスクを登録した場合' do
       before do
         visit new_task_path
-        fill_in 'Title',       with: task.title
-        fill_in 'Description', with: task.description
-        select task.status,    from: 'Status'
-        select task.priority,  from: 'Priority'
-        fill_in 'Deadline',    with: Time.current.ago(1.day)
+        fill_in Task.human_attribute_name(:title),       with: task.title
+        fill_in Task.human_attribute_name(:description), with: task.description
+        fill_in Task.human_attribute_name(:deadline),    with: Time.current.ago(1.day)
+        select Task.statuses_i18n[task.status],     from: Task.human_attribute_name(:status)
+        select Task.priorities_i18n[task.priority], from: Task.human_attribute_name(:priority)
       end
 
       it 'タスクが登録されないこと' do  
-        expect { click_button 'Save' }.to change(Task, :count).by(0)
+        expect { click_button I18n.t('common.save') }.to change(Task, :count).by(0)
       end
     end
   end
@@ -38,8 +38,8 @@ RSpec.describe 'タスクの登録・更新・削除', type: :feature, js: true 
     context '正常な入力値でタスクを登録した場合' do
       before do
         visit edit_task_path(task)
-        fill_in 'Title', with: 'edited'
-        click_button 'Save'
+        fill_in Task.human_attribute_name(:title), with: 'edited'
+        click_button I18n.t('common.save')
       end
 
       it 'タスクが更新されること' do
@@ -50,9 +50,9 @@ RSpec.describe 'タスクの登録・更新・削除', type: :feature, js: true 
     context '異常な入力値でタスクを更新した場合' do
       before do
         visit edit_task_path(task)
-        fill_in 'Title',    with: 'edited'
-        fill_in 'Deadline', with: Time.current.ago(1.day)
-        click_button 'Save'
+        fill_in Task.human_attribute_name(:title),    with: 'edited'
+        fill_in Task.human_attribute_name(:deadline), with: Time.current.ago(1.day)
+        click_button I18n.t('common.save')
       end
 
       it 'タスクが更新されないこと' do  
@@ -66,7 +66,7 @@ RSpec.describe 'タスクの登録・更新・削除', type: :feature, js: true 
     before { visit tasks_path }
 
     it 'タスクが削除されること' do
-      expect { first('tbody tr').click_link 'Destroy' }.to change(Task, :count).by(-1)
+      expect { first('tbody tr').click_link I18n.t('common.destroy') }.to change(Task, :count).by(-1)
     end
   end
 end

--- a/spec/features/tasks/index_show_spec.rb
+++ b/spec/features/tasks/index_show_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 RSpec.describe '登録したタスクを確認する', type: :feature, js: true do
-  let!(:task1) { FactoryBot.create(:task, title: 'タイトル1') }
+  let!(:task1) { FactoryBot.create(:task, title: 'タイトル1', status: Task.statuses[:done]) }
   let!(:task2) { FactoryBot.create(:task, title: 'タイトル2') }
   let!(:task3) { FactoryBot.create(:task, title: 'タイトル3') }
 
@@ -12,6 +12,16 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
       expect(page).to have_content task2.title
       expect(page).to have_content task3.title
     end
+
+    it 'タイトルとステータスでタスクの検索が行えること' do
+      fill_in Task.human_attribute_name(:title),	with: task1.title
+      select Task.statuses_i18n[task1.status], from: Task.human_attribute_name(:status)
+      click_button I18n.t('common.search')
+      expect(page).to have_content task1.title
+      expect(page).to_not have_content task2.title
+      expect(page).to_not have_content task3.title
+    end
+
   end
 
   describe "タスク詳細" do

--- a/spec/features/tasks/index_show_spec.rb
+++ b/spec/features/tasks/index_show_spec.rb
@@ -13,15 +13,19 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
       expect(page).to have_content task3.title
     end
 
-    it 'タイトルとステータスでタスクの検索が行えること' do
-      fill_in Task.human_attribute_name(:title),	with: task1.title
-      select Task.statuses_i18n[task1.status], from: Task.human_attribute_name(:status)
-      click_button I18n.t('common.search')
-      expect(page).to have_content task1.title
-      expect(page).to_not have_content task2.title
-      expect(page).to_not have_content task3.title
-    end
+    describe 'タスク検索' do
+      before do
+        fill_in Task.human_attribute_name(:title),	with: task1.title
+        select Task.statuses_i18n[task1.status], from: Task.human_attribute_name(:status)
+        click_button I18n.t('common.search')
+      end
 
+      it 'タイトルとステータスでタスクの検索が行えること' do
+        expect(page).to have_content task1.title
+        expect(page).to_not have_content task2.title
+        expect(page).to_not have_content task3.title
+      end
+    end
   end
 
   describe "タスク詳細" do


### PR DESCRIPTION
# やったこと 💪 
下記を行いました(・∀・)
 ステップ15: ステータスを追加して、検索できるようにしよう
 * [x] ステータス（未着手・着手中・完了）を追加してみよう
 * [x] 一覧画面でタイトルとステータスで検索ができるようにしよう
 * [x] 絞り込んだ際、ログを見て発行されるSQLの変化を確認してみましょう
 * [ ] 検索インデックスを貼りましょう
 * [x] 検索に対してmodel specを追加してみよう（feature specも拡充しておきましょう）

それと、テストコードのi18n化が漏れていたので、対応しました。。。 😭 

# 工夫したこと ✨ 

# 困ったこと 😢 
* 検索後に検索条件がクリアされてしまう問題への対応(._.)
* 検索フォームの良い感じの作り方がよくわからん。。。
