### PR TITLE
期限・優先順位での並び替え機能を実装しました

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -49,7 +49,7 @@ class TasksController < ApplicationController
   private
 
   def order_string
-    return 'deadline DESC' unless params.key?(:order)
+    return 'created_at DESC' unless params.key?(:order)
     order_params.to_h.map { |key, val| "#{key} #{val.upcase}" }.join(',')
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,7 +1,7 @@
 class TasksController < ApplicationController
   def index
     prepare_search_attr
-    @tasks = Task.all
+    @tasks = Task.all.order(order_string)
   end
 
   def search
@@ -48,6 +48,11 @@ class TasksController < ApplicationController
 
   private
 
+  def order_string
+    return 'deadline DESC' unless params.key?(:order)
+    order_params.to_h.map { |key, val| "#{key} #{val.upcase}" }.join(',')
+  end
+
   def prepare_search_attr
     @search_attr = { title: '', status: '' }
     @search_attr = task_params.delete_if { |_key, val| val.blank? } if params.key?(:task)
@@ -55,5 +60,9 @@ class TasksController < ApplicationController
 
   def task_params
     params.require(:task).permit(:title, :description, :status, :priority, :deadline)
+  end
+
+  def order_params
+    params.require(:order).permit(:deadline)
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,7 +6,7 @@ class TasksController < ApplicationController
 
   def search
     prepare_search_attr
-    @tasks = Task.search(@search_attr)
+    @tasks = Task.search(@search_attr).order(order_string)
     render :index
   end
 
@@ -54,7 +54,7 @@ class TasksController < ApplicationController
   end
 
   def prepare_search_attr
-    @search_attr = { title: '', status: '' }
+    @search_attr = { title: '' }
     @search_attr = task_params.delete_if { |_key, val| val.blank? } if params.key?(:task)
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -63,6 +63,6 @@ class TasksController < ApplicationController
   end
 
   def order_params
-    params.require(:order).permit(:deadline)
+    params.require(:order).permit(:deadline, :priority)
   end
 end

--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -1,2 +1,8 @@
 module TasksHelper
+  def order_icon(order)
+    case order
+    when 'asc'  then '▲'
+    when 'desc' then '▼'
+    end
+  end
 end

--- a/app/views/tasks/_order_form.html.haml
+++ b/app/views/tasks/_order_form.html.haml
@@ -1,0 +1,5 @@
+= form_tag(search_tasks_path, method: :get, style: 'display: inline') do
+  = hidden_field_tag 'task[title]', search_attr[:title]
+  = hidden_field_tag 'task[status]', search_attr[:status]
+  = hidden_field_tag "order[#{target}]", order
+  = submit_tag order_icon(order)

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -6,7 +6,10 @@
     %tr
       %th= Task.human_attribute_name(:title)
       %th= Task.human_attribute_name(:status)
-      %th= Task.human_attribute_name(:priority)
+      %th
+        = Task.human_attribute_name(:priority)
+        = render partial: 'order_form', locals: { target: 'priority', search_attr: @search_attr, order: 'asc' }
+        = render partial: 'order_form', locals: { target: 'priority', search_attr: @search_attr, order: 'desc' }
       %th
         = Task.human_attribute_name(:deadline)
         = render partial: 'order_form', locals: { target: 'deadline', search_attr: @search_attr, order: 'asc' }

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -9,8 +9,8 @@
       %th= Task.human_attribute_name(:priority)
       %th
         = Task.human_attribute_name(:deadline)
-        = link_to '▲', tasks_path('order[deadline]': 'asc')
-        = link_to '▼', tasks_path('order[deadline]': 'desc')
+        = render partial: 'order_form', locals: { target: 'deadline', search_attr: @search_attr, order: 'asc' }
+        = render partial: 'order_form', locals: { target: 'deadline', search_attr: @search_attr, order: 'desc' }
       %th Actions
   %tbody
     - @tasks.each do |task|

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -7,7 +7,10 @@
       %th= Task.human_attribute_name(:title)
       %th= Task.human_attribute_name(:status)
       %th= Task.human_attribute_name(:priority)
-      %th= Task.human_attribute_name(:deadline)
+      %th
+        = Task.human_attribute_name(:deadline)
+        = link_to '▲', tasks_path('order[deadline]': 'asc')
+        = link_to '▼', tasks_path('order[deadline]': 'desc')
       %th Actions
   %tbody
     - @tasks.each do |task|

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -6,7 +6,7 @@ FactoryBot.define do
     priority Task.priorities[:medium]
     status Task.statuses[:todo]
 
-    trait :low do 
+    trait :low do
       priority Task.priorities[:low]
     end
     trait :medium do
@@ -18,7 +18,7 @@ FactoryBot.define do
     trait :todo do
       status Task.statuses[:todo]
     end
-    trait :doing do 
+    trait :doing do
       status Task.statuses[:doing]
     end
     trait :done do

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -2,8 +2,27 @@ FactoryBot.define do
   factory :task do
     title 'Task title'
     description 'Task description'
-    status Task.statuses[:todo]
-    priority Task.priorities[:medium]
     deadline Time.current.since(1.day)
+    priority Task.priorities[:medium]
+    status Task.statuses[:todo]
+
+    trait :low do 
+      priority Task.priorities[:low]
+    end
+    trait :medium do
+      priority Task.priorities[:medium]
+    end
+    trait :high do
+      priority Task.priorities[:high]
+    end
+    trait :todo do
+      status Task.statuses[:todo]
+    end
+    trait :doing do 
+      status Task.statuses[:doing]
+    end
+    trait :done do
+      status Task.statuses[:done]
+    end
   end
 end

--- a/spec/features/tasks/index_show_spec.rb
+++ b/spec/features/tasks/index_show_spec.rb
@@ -50,6 +50,24 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
         expect(all('tbody tr')[1]).to have_content task2.title
         expect(all('tbody tr')[2]).to have_content task3.title
       end
+
+      it '重要度の降順で並び替えが行えること' do
+        within(all('thead th')[2]) do
+          click_button '▼'
+        end
+        expect(all('tbody tr')[0]).to have_content task3.title
+        expect(all('tbody tr')[1]).to have_content task2.title
+        expect(all('tbody tr')[2]).to have_content task1.title
+      end
+
+      it '重要度の昇順で並び替えが行えること' do
+        within(all('thead th')[2]) do
+          click_button '▲'
+        end
+        expect(all('tbody tr')[0]).to have_content task1.title
+        expect(all('tbody tr')[1]).to have_content task2.title
+        expect(all('tbody tr')[2]).to have_content task3.title
+      end
     end
   end
 

--- a/spec/features/tasks/index_show_spec.rb
+++ b/spec/features/tasks/index_show_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 RSpec.describe '登録したタスクを確認する', type: :feature, js: true do
   let!(:task1) { FactoryBot.create(:task, :low,    :done,  title: 'タイトル1', deadline: Time.current.since(1.day)) }
-  let!(:task2) { FactoryBot.create(:task, :medium, :doing, title: 'タイトル2', deadline: Time.current.since(2.day)) }
-  let!(:task3) { FactoryBot.create(:task, :high,   :todo,  title: 'タイトル3', deadline: Time.current.since(3.day)) }
+  let!(:task2) { FactoryBot.create(:task, :medium, :doing, title: 'タイトル2', deadline: Time.current.since(2.days)) }
+  let!(:task3) { FactoryBot.create(:task, :high,   :todo,  title: 'タイトル3', deadline: Time.current.since(3.days)) }
 
   describe 'タスク一覧' do
     before { visit tasks_path }
@@ -32,9 +32,9 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
       end
     end
 
-    describe 'タスクの並び替え' do      
+    describe 'タスクの並び替え' do
       it '期限の降順で並び替えが行えること' do
-        within(all('thead th')[3]) do 
+        within(all('thead th')[3]) do
           click_link '▼'
         end
         expect(all('tbody tr')[0]).to have_content task3.title
@@ -43,7 +43,7 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
       end
 
       it '期限の昇順で並び替えが行えること' do
-        within(all('thead th')[3]) do 
+        within(all('thead th')[3]) do
           click_link '▲'
         end
         expect(all('tbody tr')[0]).to have_content task1.title

--- a/spec/features/tasks/index_show_spec.rb
+++ b/spec/features/tasks/index_show_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 RSpec.describe '登録したタスクを確認する', type: :feature, js: true do
-  let!(:task1) { FactoryBot.create(:task, title: 'タイトル1', status: Task.statuses[:done]) }
-  let!(:task2) { FactoryBot.create(:task, title: 'タイトル2') }
-  let!(:task3) { FactoryBot.create(:task, title: 'タイトル3') }
+  let!(:task1) { FactoryBot.create(:task, :low,    :done,  title: 'タイトル1', deadline: Time.current.since(1.day)) }
+  let!(:task2) { FactoryBot.create(:task, :medium, :doing, title: 'タイトル2', deadline: Time.current.since(2.day)) }
+  let!(:task3) { FactoryBot.create(:task, :high,   :todo,  title: 'タイトル3', deadline: Time.current.since(3.day)) }
 
   describe 'タスク一覧' do
     before { visit tasks_path }
@@ -29,6 +29,26 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
       it '検索後も入力値が保持されること' do
         expect(page).to have_field Task.human_attribute_name(:title), with: task1.title
         expect(page).to have_select Task.human_attribute_name(:status), selected: Task.statuses_i18n[task1.status]
+      end
+    end
+
+    describe 'タスクの並び替え' do      
+      it '期限の降順で並び替えが行えること' do
+        within(all('thead th')[3]) do 
+          click_link '▼'
+        end
+        expect(all('tbody tr')[0]).to have_content task3.title
+        expect(all('tbody tr')[1]).to have_content task2.title
+        expect(all('tbody tr')[2]).to have_content task1.title
+      end
+
+      it '期限の昇順で並び替えが行えること' do
+        within(all('thead th')[3]) do 
+          click_link '▲'
+        end
+        expect(all('tbody tr')[0]).to have_content task1.title
+        expect(all('tbody tr')[1]).to have_content task2.title
+        expect(all('tbody tr')[2]).to have_content task3.title
       end
     end
   end

--- a/spec/features/tasks/index_show_spec.rb
+++ b/spec/features/tasks/index_show_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
     describe 'タスクの並び替え' do
       it '期限の降順で並び替えが行えること' do
         within(all('thead th')[3]) do
-          click_link '▼'
+          click_button '▼'
         end
         expect(all('tbody tr')[0]).to have_content task3.title
         expect(all('tbody tr')[1]).to have_content task2.title
@@ -44,7 +44,7 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
 
       it '期限の昇順で並び替えが行えること' do
         within(all('thead th')[3]) do
-          click_link '▲'
+          click_button '▲'
         end
         expect(all('tbody tr')[0]).to have_content task1.title
         expect(all('tbody tr')[1]).to have_content task2.title


### PR DESCRIPTION
# やったこと 💪
並び替え関係の下記を実装しました(・∀・)

> * ステップ11: タスク一覧を作成日時の順番で並び替えよう
>   * 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
> * ステップ14: 終了期限を追加しよう
>   * 一覧画面で、終了期限でソートできるようにしましょう
> * ステップ16: 優先順位を設定しよう（※類似した実装経験のある人は省略可）
>   * 優先順位でソートできるようにしましょう

# 工夫したこと ✨
* 並び替え時も検索条件が保持されるようにした！ 👍 
* order指定部分は`order_string`と`_order_form.html.haml`で共通化して簡単に追加出来るようにした😀 

# 困ったこと 😢 
* 最初リンクでgetパラメーターにソート順の情報を付与していたときに、`click_link`でテストしてたけど、通ったり落ちたりしてハマった。。。
  * `form_tag`を使用して、`click_button`で行うようにしたら安定したけど、良くわからない... 😦 
    複数する項目から特定な項目を指定してclickするとかいうのは安定しないのかも。。。
* ソート時にも検索条件を保持するために、`hidden_tag`を埋め込んでいるが、このやり方はいまいちな気がしている。。。

# Memo 📝
