### PR TITLE
期限切れのタスクはアラート表示するようにした

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -53,6 +53,7 @@ group :development, :test do
   gem "spring-commands-rspec"
   gem 'pry-rails'
   gem 'better_errors'
+  gem 'timecop'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -311,6 +311,7 @@ GEM
     thor (0.20.0)
     thread_safe (0.3.6)
     tilt (2.0.8)
+    timecop (0.9.1)
     turbolinks (5.1.1)
       turbolinks-source (~> 5.1)
     turbolinks-source (5.1.0)
@@ -367,6 +368,7 @@ DEPENDENCIES
   spring
   spring-commands-rspec
   spring-watcher-listen (~> 2.0.0)
+  timecop
   turbolinks (~> 5)
   tzinfo-data
   uglifier (>= 1.3.0)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -5,6 +5,7 @@ class TasksController < ApplicationController
 
   def index
     prepare_search_attr
+    @expired_tasks = Task.expired.where(user_id: current_user.id)
     @tasks = Task.all
                  .order(order_string)
                  .includes(:user, :labels)
@@ -14,6 +15,7 @@ class TasksController < ApplicationController
 
   def search
     prepare_search_attr
+    @expired_tasks = Task.expired.where(user_id: current_user.id)
     @tasks = Task.search(@search_attr)
                  .order(order_string)
                  .includes(:user, :labels)

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,6 +11,8 @@ class Task < ApplicationRecord
   validates :priority, presence: true
   validate  :deadline_cannot_be_in_the_past, if: -> { deadline.present? }
 
+  scope :expired, -> { where('deadline <= ?', Date.today) }
+
   def deadline_cannot_be_in_the_past
     errors.add(:deadline, 'は現在日付以降の日時を設定してください。') if deadline < Time.current.beginning_of_day
   end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,7 +11,7 @@ class Task < ApplicationRecord
   validates :priority, presence: true
   validate  :deadline_cannot_be_in_the_past, if: -> { deadline.present? }
 
-  scope :expired, -> { where('deadline <= ?', Date.today) }
+  scope :expired, -> { where('deadline <= ?', Time.zone.today) }
 
   def deadline_cannot_be_in_the_past
     errors.add(:deadline, 'は現在日付以降の日時を設定してください。') if deadline < Time.current.beginning_of_day

--- a/app/views/tasks/_expered_alert.html.haml
+++ b/app/views/tasks/_expered_alert.html.haml
@@ -1,0 +1,5 @@
+%div.alert.alert-warning{ role: 'alert' }
+  =t 'message.tasks.expired'
+  %ul
+    - expired_tasks.each do |task|
+      %li= link_to task.title, task

--- a/app/views/tasks/index.html.haml
+++ b/app/views/tasks/index.html.haml
@@ -1,5 +1,7 @@
 - if notice
   %div.alert.alert-info{ role: 'alert' }= notice
+= render partial: 'expered_alert', locals: { expired_tasks: @expired_tasks } if @expired_tasks.present?
+
 %h1= t '.title'
 = render partial: 'search_form', locals: { search_attr: @search_attr }
 

--- a/config/locales/message.yml
+++ b/config/locales/message.yml
@@ -1,11 +1,13 @@
 ja:
   message:
+    tasks:
+      expired: 期限切れのタスクがあります。
     common:
-      create: 'の作成に成功しました。'
-      update: 'の更新に成功しました。'
-      destroy: 'の削除に成功しました。'
+      create: の作成に成功しました。
+      update: の更新に成功しました。
+      destroy: の削除に成功しました。
     login:
-      success: 'ログインに成功しました。'
-      failed: 'ログインに失敗しました。アカウント情報をご確認ください。'
+      success: ログインに成功しました。
+      failed: ログインに失敗しました。アカウント情報をご確認ください。
     logout:
-      success: 'ログアウトに成功しました。'
+      success: ログアウトに成功しました。

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,5 +1,7 @@
 FactoryBot.define do
   factory :task do
+    association :user, factory: :user
+
     title 'Task title'
     description 'Task description'
     deadline Time.current.since(1.day)

--- a/spec/features/tasks/index_show_spec.rb
+++ b/spec/features/tasks/index_show_spec.rb
@@ -23,6 +23,19 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
       end
     end
 
+    describe '期限切れのアラート表示' do
+      let!(:expired_task) { FactoryBot.create(:task, title: 'タイトル_期限切れ', deadline: Time.current, user: current_user) }
+      before { Timecop.travel(5.day.since) }
+      after { Timecop.return }
+
+      it '期限切れタスクがアラートで表示されること' do
+        visit tasks_path
+        within find('div.alert.alert-warning') do
+          expect(page).to have_content expired_task.title
+        end
+      end
+    end
+
     describe 'ラベル' do
       let!(:task_with_label) { FactoryBot.create(:task, :with_label) }
       before { visit tasks_path }

--- a/spec/features/tasks/index_show_spec.rb
+++ b/spec/features/tasks/index_show_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe '登録したタスクを確認する', type: :feature, js: true 
 
     describe '期限切れのアラート表示' do
       let!(:expired_task) { FactoryBot.create(:task, title: 'タイトル_期限切れ', deadline: Time.current, user: current_user) }
-      before { Timecop.travel(5.day.since) }
+      before { Timecop.travel(1.day.since) }
       after { Timecop.return }
 
       it '期限切れタスクがアラートで表示されること' do


### PR DESCRIPTION
# やったこと :muscle:
下記を実装しました(・∀・)
> * オプション要件1: 終了間近や期限の過ぎたタスクがあった場合、アラートを出したい
>   ログインした時点で、どこかに終了間近や期限の過ぎたタスクを表示してみましょう

# 工夫したこと:sparkles:
`timecop`を使って、期限切れタスク表示のチェックを行いました 🕐 
https://github.com/travisjeffery/timecop

# 困ったこと :cry:
* 既読管理する場合は、alertモデルを作る必要があるけど、タスク専用にしたほうがいいのか、汎用的に作ったほうがいいのか問題がある。。。